### PR TITLE
Add support for strip firmware 08.v2

### DIFF
--- a/src/utils/deviceTypesMap.ts
+++ b/src/utils/deviceTypesMap.ts
@@ -41,6 +41,19 @@ export const deviceTypesMap: Map<number, IDeviceAPI> = new Map([
     },
   ],
   [
+    0x08,
+    {
+      description: 'RGB Strip',
+      byteOrder: ['r', 'g', 'b'],
+      simultaneousCCT: false,
+      hasColor: true,
+      hasCCT: false,
+      hasBrightness: true,
+      isEightByteProtocol: null,
+      needsPowerCommand: null,
+    },
+  ],
+  [
     0x09,
     {
       description: 'CCT Strip',


### PR DESCRIPTION
First of all, thanks for the plugin.

I had a older strip model that was identified as firmware 08.v2.

It is a generic controller for a strip. It worked using this config.

If any change is needed please let me know.